### PR TITLE
Updated to work with shopp 1.1.9.1.

### DIFF
--- a/export.php
+++ b/export.php
@@ -19,9 +19,9 @@ $results = $wpdb->get_results($sql, "ARRAY_A");
 foreach ($results as $row)
 {
 	$id = $row['id'];
-	$therow = $wpdb->get_row("SELECT name, data FROM wp_shopp_asset WHERE id = $id", "ARRAY_A");
+	$therow = $wpdb->get_row("SELECT data FROM wp_shopp_asset WHERE id = $id", "ARRAY_A");
 	$image = $therow["data"];
-	$name = $therow["name"];
+	$name = "image" . "_" . $id .".jpg";
 	
 	echo "File name: ".$path."$name <br />";
 	$file = fopen($path."$name","w");


### PR DESCRIPTION
The name column seems to have been removed from the db structure.
So I name the files image_<id>.jpg. The filename ending might obviously not be correct in all cases.
